### PR TITLE
server: routes for getting announcement and attestation by event_id

### DIFF
--- a/kormir-server/src/main.rs
+++ b/kormir-server/src/main.rs
@@ -97,6 +97,8 @@ async fn main() -> anyhow::Result<()> {
         .route("/health-check", get(health_check))
         .route("/pubkey", get(get_pubkey))
         .route("/list-events", get(list_events))
+        .route("/announcement/:event_id", get(get_oracle_announcement))
+        .route("/attestation/:event_id", get(get_oracle_attestation))
         .route("/create-enum", post(create_enum_event))
         .route("/sign-enum", post(sign_enum_event))
         .fallback(fallback)

--- a/kormir-server/src/models/event.rs
+++ b/kormir-server/src/models/event.rs
@@ -79,6 +79,16 @@ impl Event {
             .optional()?)
     }
 
+    pub fn get_by_event_id(
+        conn: &mut PgConnection,
+        event_id: String,
+    ) -> anyhow::Result<Option<Self>> {
+        Ok(events::table
+            .filter(events::name.eq(event_id))
+            .first::<Self>(conn)
+            .optional()?)
+    }
+
     pub fn list(conn: &mut PgConnection) -> anyhow::Result<Vec<Self>> {
         Ok(events::table.load::<Self>(conn)?)
     }

--- a/kormir-server/src/models/mod.rs
+++ b/kormir-server/src/models/mod.rs
@@ -88,6 +88,43 @@ impl PostgresStorage {
         .map_err(|_| Error::StorageFailure)
     }
 
+    pub fn get_oracle_event_by_event_id(
+        &self,
+        event_id: String,
+    ) -> anyhow::Result<Option<OracleEventData>> {
+        let mut conn = self.db_pool.get().map_err(|_| Error::StorageFailure)?;
+        let Some(event) = Event::get_by_event_id(&mut conn, event_id)? else {
+            return Ok(None);
+        };
+        let event_nonces = EventNonce::get_by_event_id(&mut conn, event.id)?;
+
+        let indexes = event_nonces
+            .iter()
+            .map(|nonce| nonce.index as u32)
+            .collect::<Vec<_>>();
+
+        let signatures = event_nonces
+            .into_iter()
+            .flat_map(|nonce| nonce.outcome_and_sig())
+            .collect();
+
+        let announcement_event_id = event.announcement_event_id().map(|ann| ann.to_string());
+        let attestation_event_id = event.attestation_event_id().map(|att| att.to_string());
+
+        Ok(Some(OracleEventData {
+            id: Some(event.id as u32),
+            announcement: OracleAnnouncement {
+                announcement_signature: event.announcement_signature(),
+                oracle_public_key: self.oracle_public_key,
+                oracle_event: event.oracle_event(),
+            },
+            indexes,
+            signatures,
+            announcement_event_id,
+            attestation_event_id,
+        }))
+    }
+
     pub async fn add_announcement_event_id(&self, id: u32, event_id: EventId) -> Result<(), Error> {
         let mut conn = self.db_pool.get().map_err(|_| Error::StorageFailure)?;
         let id = id as i32;


### PR DESCRIPTION
Makes it easier for rust-dlc consumers to consume announcements and attestations for the `Oracle` trait