### PR TITLE
fix saving nonce index in postgres

### DIFF
--- a/kormir-server/src/models/mod.rs
+++ b/kormir-server/src/models/mod.rs
@@ -158,9 +158,8 @@ impl Storage for PostgresStorage {
             let new_event_nonces = indexes
                 .into_iter()
                 .zip(announcement.oracle_event.oracle_nonces)
-                .enumerate()
-                .map(|(index, (id, nonce))| NewEventNonce {
-                    id: id as i32,
+                .map(|(index, nonce)| NewEventNonce {
+                    id: index as i32,
                     event_id,
                     index: index as i32,
                     nonce: nonce.serialize().to_vec(),

--- a/kormir/src/lib.rs
+++ b/kormir/src/lib.rs
@@ -170,7 +170,9 @@ impl<S: Storage> Oracle<S> {
         );
 
         // verify our nonce is the same as the one in the announcement
-        debug_assert!(sig.encode()[..32] == nonce_key.x_only_public_key(&self.secp).0.serialize());
+        debug_assert!(
+            sig.encode()[..32] == data.announcement.oracle_event.oracle_nonces[0].serialize()
+        );
 
         // verify our signature
         if self


### PR DESCRIPTION
The use of enumerate was overriding the index. Every index was getting saved as 0, so the wrong nonce was being used in creating the signature.
